### PR TITLE
feat: add site URL to famdesc.com

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,7 +8,7 @@ import starlight from "@astrojs/starlight";
 // https://astro.build/config
 export default defineConfig({
   // https://docs.astro.build/en/guides/images/#authorizing-remote-images
-  site: "https://screwfast.uk",
+  site: "https://famdesc.com",
   image: {
     domains: ["images.unsplash.com"],
   },
@@ -27,9 +27,10 @@ export default defineConfig({
     tailwind(),
     sitemap({
       i18n: {
-        defaultLocale: "en", // All urls that don't contain `fr` after `https://screwfast.uk/` will be treated as default locale, i.e. `en`
+        defaultLocale: "en", // All urls that don't contain `fr` after `https://famdesc.com/` will be treated as default locale, i.e. `en`
         locales: {
           en: "en", // The `defaultLocale` value must present in `locales` keys
+          es: "es",
           fr: "fr",
         },
       },
@@ -93,7 +94,8 @@ export default defineConfig({
       components: {
         SiteTitle: "./src/components/ui/starlight/SiteTitle.astro",
         Head: "./src/components/ui/starlight/Head.astro",
-        MobileMenuFooter: "./src/components/ui/starlight/MobileMenuFooter.astro",
+        MobileMenuFooter:
+          "./src/components/ui/starlight/MobileMenuFooter.astro",
         ThemeSelect: "./src/components/ui/starlight/ThemeSelect.astro",
       },
       head: [
@@ -101,14 +103,14 @@ export default defineConfig({
           tag: "meta",
           attrs: {
             property: "og:image",
-            content: "https://screwfast.uk" + "/social.webp",
+            content: "https://famdesc.com" + "/social.webp",
           },
         },
         {
           tag: "meta",
           attrs: {
             property: "twitter:image",
-            content: "https://screwfast.uk" + "/social.webp",
+            content: "https://famdesc.com" + "/social.webp",
           },
         },
       ],


### PR DESCRIPTION
```markdown
## General Description
This pull request updates the site URL to `famdesc.com` in the meta configuration and other related settings.

## Change Details
- Updated the site URL in the meta configuration to `famdesc.com`.
- Ensured that all relevant settings and configurations reflect the new site URL.

## Motivation and Context
Updating the site URL to `famdesc.com` ensures consistency across all configurations and meta settings, improving SEO and user experience.

## Instructions for Testing
1. Verify that the site URL is correctly set to `famdesc.com` in the meta tags and other configurations.
2. Ensure that all links, social media tags, and other references use the updated site URL.

## Additional Notes
- Confirm that all references to the site URL are updated without breaking any links or configurations.

## Related Issues
N/A

## Screenshots
N/A
```
