### PR TITLE
correct the URLs and meta-tags of the Contact page in both the English and Spanish versions.

### DIFF
--- a/src/components/sections/navbar&footer/FooterSection.astro
+++ b/src/components/sections/navbar&footer/FooterSection.astro
@@ -31,7 +31,11 @@ const sectionThreeContent: string =
       ? "Abonnez-vous pour recevoir les dernières mises à jour et fonctionnalités!"
       : "Subscribe now for the latest updates and features on Famdesc!";
 const crafted: string =
-  Astro.currentLocale === "fr" ? "Fabriqué par" : "Crafted by";
+  Astro.currentLocale === "es"
+    ? "Desarrollado por"
+    : Astro.currentLocale === "fr"
+      ? "Fabriqué par"
+      : "Crafted by";
 ---
 
 <footer class="w-full bg-neutral-300 dark:bg-neutral-900">

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -13,19 +13,19 @@ const pageTitle: string = `Contact | ${SITE.title}`;
   structuredData={{
     "@context": "https://schema.org",
     "@type": "WebPage",
-    "@id": "https://screwfast.uk/contact",
-    "url": "https://screwfast.uk/contact",
-    "name": "Contact Us | ScrewFast",
-    "description":
-      "Have questions or want to discuss a project? Reach out, and let's craft the perfect solution with our tools and services.",
-    "isPartOf": {
+    "@id": "https://famdesc.com/contact",
+    url: "https://famdesc.com/contact",
+    name: "Contáctanos | Famdesc",
+    description:
+      "Interested in learning more about our vision? Do you have any questions or comments about our platform? We want to hear from you!",
+    isPartOf: {
       "@type": "WebSite",
-      "url": "https://screwfast.uk",
-      "name": "ScrewFast",
-      "description":
-        "ScrewFast offers top-tier hardware tools and expert construction services to meet all your project needs.",
+      url: "https://famdesc.com",
+      name: "Famdesc",
+      description:
+        "Famdesc offers premium digital tools and services to strengthen family ties and preserve important memories.",
     },
-    "inLanguage": "en-US"
+    inLanguage: "en-US",
   }}
 >
   <ContactSection />

--- a/src/pages/es/contact.astro
+++ b/src/pages/es/contact.astro
@@ -1,0 +1,30 @@
+---
+// Import the necessary components
+import MainLayout from "@/layouts/MainLayout.astro";
+import ContactSection from "@components/sections/fr/ContactSection_fr.astro";
+---
+
+<!--Utilizing MainLayout for the outer layout of the page, and defining meta for SEO purposes-->
+<MainLayout
+  title="Contact | Famdesc"
+  lang="es"
+  structuredData={{
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": "https://famdesc.com/es/contact",
+    url: "https://famdesc.com/es/contact",
+    name: "Contáctanos | Famdesc",
+    description:
+      "¿Le interesa saber más sobre nuestra visión? ¿Tiene alguna pregunta o comentario sobre nuestra plataforma? Estaremos encantados de escucharle.",
+    isPartOf: {
+      "@type": "WebSite",
+      url: "https://famdesc.com/es/",
+      name: "Famdesc",
+      description:
+        "Famdesc ofrece herramientas y servicios digitales de primera calidad para fortalecer los lazos familiares y preservar recuerdos importantes.",
+    },
+    inLanguage: "es",
+  }}
+>
+  <ContactSection />
+</MainLayout>


### PR DESCRIPTION
## General Description
This pull request corrects the URLs and meta tags for the Contact page on both the English and Spanish versions of the site. It ensures that the SEO metadata accurately reflects the page content and that the URLs are consistent with the correct domain and language prefix.

## Change Details
- **Domain and URL Correction:** Updated the domain to `famdesc.com` and ensured that the language prefix `es` is used correctly in the Spanish version.
- **Meta Tag Adjustments:** Revised meta descriptions and structured data, including the `@id` and `url` fields, to align with the proper page URLs.
- **SEO Optimization:** Ensured the structured data accurately represents the page's purpose and content, improving search engine visibility and accuracy.

## Motivation and Context
The changes are made to correct previously incorrect URLs and enhance the SEO setup for the Contact page, ensuring users and search engines receive accurate and language-specific content.

## Instructions for Testing
1. **URL Check:** Verify that the Contact page URLs in the structured data and meta tags correctly reflect the domain `famdesc.com` and the language prefix `es` for the Spanish version.
2. **SEO Metadata:** Ensure that the meta descriptions and structured data descriptions accurately describe the content of the Contact page.
3. **Language-Specific Content:** Check that the structured data is correctly localized for both English and Spanish.

## Additional Notes
- This update is part of ongoing efforts to improve the site's SEO and ensure accurate and user-friendly URLs and metadata.
- No new features are added; this is a correction and optimization task.

## Related Issues
N/A

## Screenshots
N/A

