### PR TITLE
feat: add Spanish translation for Contact Us page

### DIFF
--- a/src/components/sections/es/ContactSection_es.astro
+++ b/src/components/sections/es/ContactSection_es.astro
@@ -1,0 +1,122 @@
+---
+// Import the necessary dependencies.
+import AuthBtn from "@components/ui/buttons/AuthBtn.astro";
+import ContactIconBlock from "@components/ui/blocks/ContactIconBlock.astro";
+import TextInput from "@components/ui/forms/input/TextInput.astro";
+import EmailContactInput from "@components/ui/forms/input/EmailContactInput.astro";
+import PhoneInput from "@components/ui/forms/input/PhoneInput.astro";
+import TextAreaInput from "@components/ui/forms/input/TextAreaInput.astro";
+import Icon from "@components/ui/icons/Icon.astro";
+
+// Define the variables that will be used in this component
+const title: string = "Contacta al Equipo de Famdesc";
+const subTitle: string =
+  "¿Interesado en aprender más sobre nuestra visión? ¿Tienes alguna pregunta o comentario sobre nuestra plataforma? ¡Queremos conocer su opinión!";
+const formTitle: string = "Llena el formulario a continuación";
+const formSubTitle: string =
+  "Nos pondremos en contacto contigo en 1-2 días hábiles.";
+---
+
+<!-- Contact Us -->
+<section class="mx-auto max-w-[85rem] px-4 py-10 sm:px-6 lg:px-8 lg:py-14">
+  <div class="mx-auto max-w-2xl lg:max-w-5xl">
+    <div class="text-center">
+      <h1
+        class="text-balance text-2xl font-bold tracking-tight text-neutral-800 dark:text-neutral-200 md:text-4xl md:leading-tight"
+      >
+        {title}
+      </h1>
+      <p class="mt-1 text-pretty text-neutral-600 dark:text-neutral-400">
+        {subTitle}
+      </p>
+    </div>
+
+    <div class="mt-12 grid items-center gap-6 lg:grid-cols-2 lg:gap-16">
+      <div class="flex flex-col rounded-xl p-4 sm:p-6 lg:p-8">
+        <h2
+          class="mb-8 text-xl font-bold text-neutral-700 dark:text-neutral-300"
+        >
+          {formTitle}
+        </h2>
+        <!-- Form for user input with various input fields.-->
+        <!-- Each field utilizes a different input component for the specific type of input (text, email, phone, and textarea)-->
+        <form>
+          <div class="grid gap-4">
+            <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <TextInput
+                id="hs-firstname-contacts"
+                label="Nombre"
+                name="hs-firstname-contacts"
+                required
+              />
+              <TextInput
+                id="hs-lastname-contacts"
+                label="Apellido"
+                name="hs-firstname-contacts"
+                required
+              />
+            </div>
+            <EmailContactInput id="hs-email-contacts" required />
+            <PhoneInput id="hs-phone-number" required={false} />
+            <TextAreaInput
+              id="hs-about-contacts"
+              label="Detalles"
+              name="hs-about-contacts"
+              required
+            />
+          </div>
+
+          <div class="mt-4 grid">
+            <AuthBtn title="Enviar Mensaje" />
+          </div>
+
+          <div class="mt-3 text-center">
+            <p class="text-sm text-neutral-600 dark:text-neutral-400">
+              {formSubTitle}
+            </p>
+          </div>
+        </form>
+      </div>
+
+      <!--ContactIconBlocks are used to display different methods of contacting, including visiting office, email, browsing knowledgebase, and FAQ.-->
+      <div class="divide-y divide-neutral-300 dark:divide-neutral-700">
+        <ContactIconBlock
+          heading="Base de conocimientos"
+          content="Explora todos nuestros artículos de la base de conocimientos."
+          isLinkVisible={true}
+          linkTitle="Visitar guías y tutoriales"
+          linkURL="#"
+          isArrowVisible={true}
+          ><Icon name="question" />
+        </ContactIconBlock>
+
+        <ContactIconBlock
+          heading="Preguntas Frecuentes"
+          content="Explora nuestras preguntas frecuentes para obtener respuestas rápidas y claras a consultas comunes."
+          isLinkVisible={true}
+          linkTitle="Visitar FAQ"
+          linkURL="#"
+          isArrowVisible={true}
+          ><Icon name="chatBubble" />
+        </ContactIconBlock>
+
+        <ContactIconBlock
+          heading="Visita nuestra oficina"
+          content="Famdesc LLC"
+          isAddressVisible={false}
+          addressContent="Habana"
+          ><Icon name="mapPin" />
+        </ContactIconBlock>
+
+        <ContactIconBlock
+          heading="Contáctanos por correo electrónico"
+          content="¿Prefieres la palabra escrita? Envíanos un correo electrónico a"
+          isLinkVisible={true}
+          linkTitle="contact@famdesc.com"
+          linkURL="mailto:contact@famdesc.com"
+          ><Icon name="envelopeOpen" />
+        </ContactIconBlock>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/pages/es/contact.astro
+++ b/src/pages/es/contact.astro
@@ -1,7 +1,7 @@
 ---
 // Import the necessary components
 import MainLayout from "@/layouts/MainLayout.astro";
-import ContactSection from "@components/sections/fr/ContactSection_fr.astro";
+import ContactSection from "@components/sections/es/ContactSection_es.astro";
 ---
 
 <!--Utilizing MainLayout for the outer layout of the page, and defining meta for SEO purposes-->


### PR DESCRIPTION
## General Description
This pull request adds Spanish translation support for the "Contact Us" page in the Famdesc platform. This update includes translated content for all text elements, ensuring a consistent user experience for Spanish-speaking users.

## Change Details
- **Title and Subtitles**: Translated the main title and subtitles of the contact page to Spanish.
- **Form Labels**: Updated labels for form fields (e.g., first name, last name, details) to Spanish.
- **ContactIconBlocks**: Translated headings and content for the various contact options, including Knowledgebase, FAQ, visiting the office, and email contact.

## Motivation and Context
This update enhances the accessibility and usability of the Famdesc platform for Spanish-speaking users. It aligns with our commitment to providing a localized experience that caters to a diverse audience.

## Instructions for Testing
1. Navigate to the "Contact Us" page with the site language set to Spanish.
2. Verify that all text elements are displayed in Spanish.
3. Ensure the form fields and ContactIconBlocks are accurately translated and maintain proper layout and design consistency.
4. Test form submission to ensure no functionality is impacted by the translation.

## Additional Notes
- Review translations for accuracy and appropriateness in the context of the platform.
- Check for any visual discrepancies or issues that may have arisen due to text length changes in the translated content.

## Related Issues
- N/A

## Screenshots

!["Contact Us" page with Spanish translations](https://github.com/user-attachments/assets/b7b29393-bf04-4239-b970-5c4a0ba68127)
