### PR TITLE
Improve language selection logic and URL handling

### DIFF
--- a/src/components/ui/LanguagePicker.astro
+++ b/src/components/ui/LanguagePicker.astro
@@ -161,14 +161,12 @@ const currentLanguage: TLanguage = supportedLanguages.includes(
         event.preventDefault();
 
         const url = new URL(window.location.href);
-        const activeLang = languages.includes(
-          url.pathname.split("/").filter(Boolean)[0] as TLanguage,
-        )
-          ? (url.pathname.split("/").filter(Boolean)[0] as TLanguage)
+        const urlParts = url.pathname.split("/").filter(Boolean);
+        const activeLang = languages.includes(urlParts[0] as TLanguage)
+          ? (urlParts[0] as TLanguage)
           : "en";
-        const pathParts = url.pathname
-          .split("/")
-          .filter((part) => part && !languages.includes(part as TLanguage));
+        const routeParts =
+          activeLang === "en" ? urlParts : urlParts.slice(1);
 
         // Disable the selection of the same language
         if (lang === activeLang) {
@@ -177,23 +175,31 @@ const currentLanguage: TLanguage = supportedLanguages.includes(
         }
 
         if (
-          url.pathname.includes("/post") ||
-          url.pathname.includes("/insight")
+          routeParts.length > 1 &&
+          (routeParts[0] === "blog" || routeParts[0] === "insights")
         ) {
-          if (url.pathname.includes("en")) {
-            pathParts.unshift(lang);
-            pathParts.splice(2, 0, lang);
-          } else {
-            pathParts.unshift(lang);
-            pathParts.splice(2, 0, "en");
-          }
-        } else {
+          const contentSlugParts = languages.includes(
+            routeParts[1] as TLanguage,
+          )
+            ? routeParts.slice(2)
+            : routeParts.slice(1);
+          const pathParts = [routeParts[0], lang, ...contentSlugParts];
+
           if (lang !== "en") {
             pathParts.unshift(lang);
           }
+
+          url.pathname = pathParts.join("/");
+        } else {
+          const pathParts = activeLang === "en" ? urlParts : urlParts.slice(1);
+
+          if (lang !== "en") {
+            pathParts.unshift(lang);
+          }
+
+          url.pathname = pathParts.join("/");
         }
 
-        url.pathname = pathParts.join("/");
         window.location.href = url.toString();
       });
     });


### PR DESCRIPTION
## General Description
Small refactor of the LanguagePicker component to clarify and fix URL parsing and language-switching behavior. The change centralizes pathname parsing, differentiates routes with/without language prefixes, and ensures content slugs are preserved when switching languages (e.g. /blog/slug ↔ /es/blog/slug).

Refactored the logic that builds and navigates to language-specific routes in `LanguagePicker` to:
- Avoid repeated parsing of `window.location.pathname`.
- Distinguish routes that already include a language prefix from those in the default language ("en").
- Build consistent path arrays when switching languages for content pages (blog/insights) and for generic routes.

## Change Details
- File: `src/components/ui/LanguagePicker.astro`
  - Consolidated repeated `url.pathname.split("/")` calls into a single `urlParts` variable.
  - Introduced `routeParts` to clearly handle whether the current route contains a language prefix.
  - Simplified construction of `pathParts` for content routes (blog/insights) and for general routes.
  - Fixed logic to preserve content slugs when toggling to/from the default language (`en`).
  - Assigned `url.pathname` explicitly before redirecting via `window.location.href`.

## Motivation and Context
- Prevent cases where switching languages caused loss or corruption of the content slug.
- Improve readability and maintainability by reducing duplicated array manipulation and making intent explicit.
- Ensure consistent behavior across content pages (blog/insights) and other routes, with or without a language prefix.

## Instructions for Testing
1. Visit a default-English route (no prefix), e.g. `/blog/my-post` or `/insights/my-article`.
2. Use the LanguagePicker to switch to another language (e.g. Spanish):
   - Expect URL: `/es/blog/my-post` or `/es/insights/my-article`.
3. From a prefixed route (e.g. `/es/blog/my-post`) switch back to English:
   - Expect URL: `/blog/my-post` (no `en` prefix).
4. Test non-content routes (e.g. `/about`) switching languages:
   - Expect prefix added/removed correctly, preserving the route.
5. Test slugs that contain segments that could be mistaken for language codes to ensure they are not mis-parsed as language prefixes.

## Additional Notes
- Changes are contained to a single UI component; low risk.
- Should not break existing routes — logic attempts to preserve the current slug and only add/remove language prefixes as required.
- If there are complex nested routes or custom route prefixes, further adjustments and tests may be needed.

## Related Issues / References
- No explicit issue linked in the comparison.
- Diff reference: https://github.com/Famdesc/Famdesc-UI/compare/main...development?expand=1

## Screenshots
- Not applicable for this logic-only change.