### PR TITLE
Centralize contact & waitlist forms and add Google Apps Script backend

### DIFF
--- a/scripts/google-apps-script/contact-waitlist-webapp.gs
+++ b/scripts/google-apps-script/contact-waitlist-webapp.gs
@@ -39,6 +39,7 @@ function doPost(e) {
     if (!isAllowedOrigin_(data.origin)) {
       return json_({
         success: false,
+        code: "origin_not_allowed",
         message: "Verification failed. Please try again.",
       });
     }
@@ -55,6 +56,7 @@ function doPost(e) {
     if (isSpam_(data)) {
       return json_({
         success: false,
+        code: "spam_check_failed",
         message: "Verification failed. Please try again.",
       });
     }
@@ -62,6 +64,7 @@ function doPost(e) {
     if (!verifyTurnstile_(data.turnstileToken)) {
       return json_({
         success: false,
+        code: "turnstile_failed",
         message: "Verification failed. Please refresh the challenge and try again.",
       });
     }
@@ -69,6 +72,7 @@ function doPost(e) {
     if (hasRecentSubmission_(data)) {
       return json_({
         success: false,
+        code: "rate_limited",
         message: "Verification failed. Please try again.",
       });
     }
@@ -144,7 +148,7 @@ function normalizePayload_(data) {
     inquiryType: clean_(data.inquiryType),
     interest: clean_(data.interest),
     language: clean_(data.language || "en"),
-    website: clean_(data.website),
+    honeypot: clean_(data.companyFax || data.website),
     turnstileToken: clean_(data.turnstileToken),
     formStartedAt: Number(data.formStartedAt || 0),
     submittedAt: clean_(data.submittedAt || new Date().toISOString()),
@@ -196,7 +200,7 @@ function validatePayload_(data) {
 }
 
 function isSpam_(data) {
-  if (data.website) return true;
+  if (data.honeypot) return true;
 
   const text = `${data.subject} ${data.message}`.toLowerCase();
   const links = text.match(/https?:\/\//g) || [];

--- a/src/components/sections/misc/ContactFormSection.astro
+++ b/src/components/sections/misc/ContactFormSection.astro
@@ -56,9 +56,9 @@ const optionClass = "bg-white text-neutral-800 dark:bg-neutral-800 dark:text-neu
         <input
           class="hidden"
           type="text"
-          name="website"
+          name="companyFax"
           tabindex="-1"
-          autocomplete="off"
+          autocomplete="new-password"
           aria-hidden="true"
         />
 

--- a/src/components/sections/misc/WaitlistSection.astro
+++ b/src/components/sections/misc/WaitlistSection.astro
@@ -55,9 +55,9 @@ const optionClass = "bg-white text-neutral-800 dark:bg-neutral-800 dark:text-neu
         <input
           class="hidden"
           type="text"
-          name="website"
+          name="companyFax"
           tabindex="-1"
-          autocomplete="off"
+          autocomplete="new-password"
           aria-hidden="true"
         />
 

--- a/src/utils/contactFormHandler.ts
+++ b/src/utils/contactFormHandler.ts
@@ -314,7 +314,7 @@ async function submitForm(form: HTMLFormElement, endpoint: string) {
     }
 
     resetTurnstile(form);
-    const message = payload.message || successMessage;
+    const message = successMessage || payload.message || fallbackError;
 
     if (!openSuccessModal(submitterName, message)) {
       setMessage(form, message, "success");

--- a/src/utils/contactFormHandler.ts
+++ b/src/utils/contactFormHandler.ts
@@ -118,11 +118,11 @@ function validateForm(form: HTMLFormElement, turnstileEnabled: boolean) {
   const errors: Record<string, string> = {};
   const name = getValue(form, "name");
   const email = getValue(form, "email");
-  const website = getValue(form, "website");
+  const honeypot = getValue(form, "companyFax");
   const turnstileToken = getValue(form, "turnstileToken");
 
-  if (website) {
-    errors.website = "Verification failed. Please try again.";
+  if (honeypot) {
+    errors.companyFax = "Verification failed. Please try again.";
   }
 
   if (name.length < 2) {


### PR DESCRIPTION
## General Description

This PR centralizes and implements the Contact and Waitlist features across locales, adds a client-side form runtime with Cloudflare Turnstile support, and introduces a Google Apps Script backend to receive, validate, persist (Google Sheets) and notify (email) form submissions. It replaces duplicated per-locale contact markup with a reusable ContactFormSection, adds localized waitlist pages and routes, updates CTAs and navigation to point to the waitlist, and improves validation, spam protection and UX for both contact and waitlist flows.

## Change Details

- **Backend (Google Apps Script):** Added scripts/google-apps-script/contact-waitlist-webapp.gs — a new web app that processes contact and waitlist POSTs, validates payloads (honeypot, minimum submit time, rate-limiting), optionally verifies Cloudflare Turnstile server-side, appends rows to Google Sheets, and sends contact emails via Gmail.
- **Reusable UI components:** Added src/components/sections/misc/ContactFormSection.astro and src/components/sections/misc/WaitlistSection.astro; updated locale-specific contact sections to import and use the shared ContactFormSection.
- **Form runtime & modal:** Added src/components/sections/misc/FormRuntime.astro — provides Turnstile script injection and a reusable success modal.
- **Client form handler:** Rewrote src/utils/contactFormHandler.ts with fetch-based submission, client-side validation, honeypot, Turnstile attachment/token handling, success modal, and rate-limit UX.
- **Localized copy:** Added src/utils/contactFormCopy.ts with localized strings for en/es/fr.
- **Pages & routes:** Added waitlist pages (src/pages/waitlist.astro, src/pages/es/waitlist.astro, src/pages/fr/waitlist.astro) and updated CTAs.
- **Navigation & UI tweaks:** Added Waitlist links to footer/nav, updated LoginBtn default URL to /waitlist, and product CTA to /waitlist.
- **Types & env:** Updated src/env.d.ts to declare PUBLIC_GOOGLE_SCRIPT_CONTACT_ENDPOINT and PUBLIC_TURNSTILE_SITE_KEY.

## Motivation and Context

- Separate product interest (waitlist) from support/contact traffic.
- Reduce duplicated localized markup with a reusable ContactFormSection.
- Persist submissions (Google Sheets) and notify via email.
- Improve spam protection with honeypot, Cloudflare Turnstile, and server-side rate limiting.
- Improve UX with client-side validation, disabled states, inline messages, and success modal.
- Align CTAs and navigation to improve product launch conversion.

## Instructions for Testing

1. Environment and Apps Script
   1. Set PUBLIC_GOOGLE_SCRIPT_CONTACT_ENDPOINT to the deployed Google Apps Script /exec URL.
   2. (Optional) Set PUBLIC_TURNSTILE_SITE_KEY to a Cloudflare Turnstile site key.
   3. In the Apps Script project, set script properties and deploy as Web App.
2. Local build & runtime
   1. Run the dev server and visit /contact, /waitlist, and localized variants.
   2. Verify localized text and Turnstile widget render.
3. Submission flows
   1. Submit Contact form and verify success modal and sheet entry.
   2. Submit Waitlist form and verify confirmation.
4. Validation and anti-spam checks
   1. Fill hidden website honeypot → rejection.
   2. Submit very quickly → blocked by time checks.
   3. Leave required fields empty → validation errors.
5. Developer checks
   1. Run full build to ensure no TypeScript/env errors.
   2. Inspect network requests for correct POST payload.

## Additional Notes

- Ensure Google Apps Script deployment has required permissions (SpreadsheetApp, GmailApp).
- Server-side Turnstile verification is optional.
- Update CI/deployment to use new env variable names.
- No automated tests added; consider adding e2e tests.

## Related Issues

- N/A.

## Screenshots

- N/A