### PR TITLE
Enhance contact form success handling and add Spanish hiring page

### DIFF
--- a/scripts/google-apps-script/contact-waitlist-webapp.gs
+++ b/scripts/google-apps-script/contact-waitlist-webapp.gs
@@ -9,6 +9,8 @@
  * - WAITLIST_SHEET_NAME: Waitlist
  */
 
+const SCRIPT_VERSION = "2026-06-22-contact-email-1";
+
 const CONFIG = {
   contactSheetName: getProperty_("CONTACT_SHEET_NAME", "Contact Submissions"),
   waitlistSheetName: getProperty_("WAITLIST_SHEET_NAME", "Waitlist"),
@@ -21,7 +23,6 @@ const CONFIG = {
   minTimeToSubmitMs: 3000,
   rateLimitSeconds: 300,
   maxMessageLength: 5000,
-  contactStatusOptions: ["Pending", "In progress", "Closed"],
 };
 
 function doGet() {
@@ -48,6 +49,7 @@ function doPost(e) {
     if (!validation.ok) {
       return json_({
         success: false,
+        code: "validation_failed",
         message: "Please check the form fields and try again.",
         errors: validation.errors,
       });
@@ -80,8 +82,8 @@ function doPost(e) {
     recordSubmissionAttempt_(data);
 
     if (data.formType === "contact") {
-      sendContactEmail_(data);
       saveContactSubmission_(data);
+      sendContactEmailSafely_(data);
 
       return json_({
         success: true,
@@ -104,6 +106,7 @@ function doPost(e) {
 
     return json_({
       success: false,
+      code: "invalid_form_type",
       message: "Invalid form type.",
     });
   } catch (error) {
@@ -111,6 +114,7 @@ function doPost(e) {
 
     return json_({
       success: false,
+      code: "internal_error",
       message:
         "We could not process your request right now. Please try again later.",
     });
@@ -265,10 +269,18 @@ function sendContactEmail_(data) {
     data.message,
   ].join("\n");
 
-  GmailApp.sendEmail(CONFIG.recipientEmail, subject, body, {
+  MailApp.sendEmail(CONFIG.recipientEmail, subject, body, {
     replyTo: data.email,
     name: "Famdesc Website",
   });
+}
+
+function sendContactEmailSafely_(data) {
+  try {
+    sendContactEmail_(data);
+  } catch (error) {
+    console.error("Contact email notification failed", error);
+  }
 }
 
 function saveContactSubmission_(data) {
@@ -285,7 +297,6 @@ function saveContactSubmission_(data) {
   ];
 
   ensureHeaders_(sheet, headers);
-  applyContactStatusValidation_(sheet);
   sheet.appendRow([
     new Date(),
     data.name,
@@ -339,23 +350,6 @@ function ensureHeaders_(sheet, headers) {
   });
 }
 
-function applyContactStatusValidation_(sheet) {
-  const lastColumn = Math.max(sheet.getLastColumn(), 1);
-  const headers = sheet.getRange(1, 1, 1, lastColumn).getValues()[0];
-  const statusColumn = headers.indexOf("Status") + 1;
-
-  if (!statusColumn) return;
-
-  const rule = SpreadsheetApp.newDataValidation()
-    .requireValueInList(CONFIG.contactStatusOptions, true)
-    .setAllowInvalid(false)
-    .build();
-
-  sheet
-    .getRange(2, statusColumn, Math.max(sheet.getMaxRows() - 1, 1), 1)
-    .setDataValidation(rule);
-}
-
 function isAllowedOrigin_(origin) {
   if (!CONFIG.allowedOrigins.length) return true;
   if (!origin) return false;
@@ -376,7 +370,10 @@ function getProperty_(key, fallback) {
 }
 
 function json_(payload) {
-  return ContentService.createTextOutput(JSON.stringify(payload)).setMimeType(
-    ContentService.MimeType.JSON,
-  );
+  return ContentService.createTextOutput(
+    JSON.stringify({
+      version: SCRIPT_VERSION,
+      ...payload,
+    }),
+  ).setMimeType(ContentService.MimeType.JSON);
 }

--- a/src/components/sections/navbar&footer/FooterSection.astro
+++ b/src/components/sections/navbar&footer/FooterSection.astro
@@ -9,31 +9,35 @@ import Icon from "@components/ui/icons/Icon.astro";
 import BrandLogo from "@components/BrandLogo.astro";
 import { SITE } from "@data/constants";
 
+const footerLocale = Astro.url.pathname.startsWith("/es")
+  ? "es"
+  : Astro.currentLocale;
+
 // Select the correct translation based on the page's lang prop:
 const strings =
-  Astro.currentLocale === "es"
+  footerLocale === "es"
     ? esStrings
-    : Astro.currentLocale === "fr"
+    : footerLocale === "fr"
       ? frStrings
       : enStrings;
 
 // Define the variables that will be used in this component
 const sectionThreeTitle: string =
-  Astro.currentLocale === "es"
+  footerLocale === "es"
     ? "Mantente al día"
-    : Astro.currentLocale === "fr"
+    : footerLocale === "fr"
       ? "Rester à jour"
       : "Stay up to date";
 const sectionThreeContent: string =
-  Astro.currentLocale === "es"
+  footerLocale === "es"
     ? "Suscríbete ahora y mantente al tanto de las últimas novedades de Famdesc!"
-    : Astro.currentLocale === "fr"
+    : footerLocale === "fr"
       ? "Abonnez-vous pour recevoir les dernières mises à jour et fonctionnalités!"
       : "Subscribe now for the latest updates and features on Famdesc!";
 const crafted: string =
-  Astro.currentLocale === "es"
+  footerLocale === "es"
     ? "Desarrollado por"
-    : Astro.currentLocale === "fr"
+    : footerLocale === "fr"
       ? "Fabriqué par"
       : "Crafted by";
 ---
@@ -63,9 +67,12 @@ const crafted: string =
                   >
                     {link.name}
                   </a>
-                  {section.section === "Company" && index === 2 ? (
+                  {(footerLocale === "es" && link.url === "/es/hiring") ||
+                  (footerLocale !== "es" &&
+                    section.section === "Company" &&
+                    index === 2) ? (
                     <span class="ms-1 inline rounded-lg bg-blue-500 px-2 py-1 text-xs font-bold text-neutral-50">
-                      We're hiring!
+                      {footerLocale === "es" ? "Contratando" : "We're hiring!"}
                     </span>
                   ) : null}
                 </li>

--- a/src/components/sections/navbar&footer/FooterSection.astro
+++ b/src/components/sections/navbar&footer/FooterSection.astro
@@ -59,7 +59,7 @@ const crafted: string =
               {section.section}
             </h3>
             <ul class="mt-3 grid space-y-3">
-              {section.links.map((link, index) => (
+              {section.links.map((link) => (
                 <li>
                   <a
                     href={link.url}
@@ -67,12 +67,9 @@ const crafted: string =
                   >
                     {link.name}
                   </a>
-                  {(footerLocale === "es" && link.url === "/es/hiring") ||
-                  (footerLocale !== "es" &&
-                    section.section === "Company" &&
-                    index === 2) ? (
+                  {link.url === "/es/hiring" ? (
                     <span class="ms-1 inline rounded-lg bg-blue-500 px-2 py-1 text-xs font-bold text-neutral-50">
-                      {footerLocale === "es" ? "Contratando" : "We're hiring!"}
+                      Contratando
                     </span>
                   ) : null}
                 </li>

--- a/src/pages/es/hiring.astro
+++ b/src/pages/es/hiring.astro
@@ -1,0 +1,299 @@
+---
+import MainLayout from "@/layouts/MainLayout.astro";
+import { Image } from "astro:assets";
+import famdescBrand from "@images/famdesc-brand-identity.avif";
+import { SITE } from "@data/constants";
+
+const pageTitle = "Hiring | Contenido Digital y Marketing | Famdesc";
+const pageDescription =
+  "Oportunidad de formación y trabajo en Famdesc para aprender edición de video, creación de contenido y marketing digital.";
+
+const basicFields = [
+  { id: "fullName", label: "Nombre y apellidos", type: "text" },
+  { id: "age", label: "Edad", type: "text" },
+  { id: "location", label: "Lugar de residencia", type: "text" },
+  { id: "phone", label: "Teléfono / WhatsApp", type: "tel" },
+  {
+    id: "currentOccupation",
+    label: "Ocupación actual, si aplica",
+    type: "text",
+  },
+] as const;
+
+const questions = [
+  "Cuéntanos brevemente sobre ti, qué haces actualmente y qué te interesa aprender.",
+  "¿Qué fue lo que más te llamó la atención de esta oportunidad?",
+  "¿Por qué te interesa aprender edición de videos, creación de contenido o marketing digital?",
+  "¿Has grabado o editado algún video anteriormente, aunque haya sido personal, escolar o para redes sociales? Si sí, explica brevemente.",
+  "¿Qué aplicaciones o programas has utilizado para editar videos, imágenes o publicaciones?",
+  "¿Te sentirías cómodo/a grabando a otras personas, ayudando a organizar una grabación o apareciendo en cámara si alguna vez fuera necesario?",
+  "¿Tienes laptop o acceso frecuente a una computadora? Indica cuál y con qué frecuencia puedes usarla.",
+  "¿Tienes acceso regular a internet y puedes descargar o enviar archivos de video relativamente pesados?",
+  "¿Qué días y horarios tienes normalmente disponibles?",
+  "¿Puedes desplazarte para realizar grabaciones previamente coordinadas? Si no vives en Songo La Maya, ¿con qué frecuencia podrías trasladarte?",
+  "Cuando tienes varias tareas pendientes, ¿cómo acostumbras a organizarte?",
+  "¿Qué haces normalmente cuando recibes una tarea y no entiendes bien cómo hacerla?",
+  "¿Cómo reaccionas cuando alguien revisa tu trabajo y te pide corregirlo o repetirlo?",
+  "Si tuvieras que grabar un video corto para presentar una empresa tecnológica como Famdesc, ¿qué idea se te ocurriría?",
+  "Además de la remuneración, ¿qué esperas obtener de esta oportunidad y cuántas horas por semana podrías comprometer de manera realista?",
+];
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "@id": `${SITE.url}/es/hiring`,
+  url: `${SITE.url}/es/hiring`,
+  name: pageTitle,
+  description: pageDescription,
+  inLanguage: "es",
+  isPartOf: {
+    "@type": "WebSite",
+    url: `${SITE.url}/es/`,
+    name: "Famdesc",
+  },
+};
+---
+
+<MainLayout
+  title={pageTitle}
+  meta={pageDescription}
+  lang="es"
+  structuredData={structuredData}
+>
+  <section class="mx-auto max-w-[85rem] px-4 py-14 sm:px-6 lg:px-8 lg:py-20">
+    <div class="grid gap-10 lg:grid-cols-[1.05fr_0.95fr] lg:items-center">
+      <div>
+        <p
+          class="text-orange-600 dark:text-orange-400 text-sm font-semibold uppercase tracking-wide"
+        >
+          Hiring Famdesc
+        </p>
+
+        <h1
+          class="mt-4 text-balance text-4xl font-bold tracking-tight text-neutral-800 dark:text-neutral-200 md:text-6xl"
+        >
+          Oportunidad de formación y trabajo en Contenido Digital y Marketing
+        </h1>
+
+        <p
+          class="mt-6 max-w-2xl text-lg text-neutral-600 dark:text-neutral-400"
+        >
+          Buscamos una persona con ganas de aprender y crecer junto a Famdesc.
+          No necesitas experiencia profesional previa; valoramos
+          responsabilidad, creatividad, capacidad de aprender y compromiso.
+        </p>
+
+        <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+          <a
+            href="#formulario"
+            class="hover:bg-salmon-600 focus-visible:ring-salmon-300 inline-flex items-center justify-center rounded-lg bg-salmon-500 px-5 py-3 text-sm font-semibold text-white transition focus:outline-none focus-visible:ring"
+          >
+            Llenar formulario
+          </a>
+          <a
+            href="#preguntas"
+            class="inline-flex items-center justify-center rounded-lg border border-neutral-300 px-5 py-3 text-sm font-semibold text-neutral-800 transition hover:bg-neutral-100 focus:outline-none focus-visible:ring focus-visible:ring-neutral-300 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-700"
+          >
+            Ver preguntas
+          </a>
+        </div>
+      </div>
+
+      <div
+        class="overflow-hidden rounded-lg border border-neutral-200 dark:border-neutral-700"
+      >
+        <Image
+          src={famdescBrand}
+          alt="Identidad visual de Famdesc como empresa tecnológica centrada en las personas y las familias"
+          class="h-full min-h-[22rem] w-full object-cover"
+        />
+      </div>
+    </div>
+  </section>
+
+  <section class="mx-auto max-w-[85rem] px-4 py-8 sm:px-6 lg:px-8">
+    <div class="grid gap-6 md:grid-cols-3">
+      <div
+        class="rounded-lg border border-neutral-200 p-6 dark:border-neutral-700"
+      >
+        <h2
+          class="text-xl font-semibold text-neutral-800 dark:text-neutral-200"
+        >
+          Qué harás
+        </h2>
+        <p class="mt-3 text-neutral-600 dark:text-neutral-400">
+          Apoyarás la creación de videos, publicaciones e ideas para Famdesc y
+          para contenidos sobre emprendimiento, tecnología, liderazgo y
+          aprendizaje.
+        </p>
+      </div>
+
+      <div
+        class="rounded-lg border border-neutral-200 p-6 dark:border-neutral-700"
+      >
+        <h2
+          class="text-xl font-semibold text-neutral-800 dark:text-neutral-200"
+        >
+          Qué aprenderás
+        </h2>
+        <p class="mt-3 text-neutral-600 dark:text-neutral-400">
+          Edición básica y progresiva de video, organización de grabaciones,
+          contenido para redes sociales, narrativa digital y criterios de
+          marketing aplicados a un proyecto real.
+        </p>
+      </div>
+
+      <div
+        class="rounded-lg border border-neutral-200 p-6 dark:border-neutral-700"
+      >
+        <h2
+          class="text-xl font-semibold text-neutral-800 dark:text-neutral-200"
+        >
+          Modalidad
+        </h2>
+        <p class="mt-3 text-neutral-600 dark:text-neutral-400">
+          Trabajo mixto: algunas tareas pueden ser remotas y otras presenciales,
+          especialmente para grabaciones coordinadas.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section
+    id="formulario"
+    class="mx-auto max-w-[85rem] px-4 py-12 sm:px-6 lg:px-8"
+  >
+    <div class="mx-auto max-w-4xl">
+      <div class="mb-8">
+        <p
+          class="text-orange-600 dark:text-orange-400 text-sm font-semibold uppercase tracking-wide"
+        >
+          Primera etapa
+        </p>
+        <h2
+          class="mt-3 text-3xl font-bold tracking-tight text-neutral-800 dark:text-neutral-200"
+        >
+          Formulario de preselección
+        </h2>
+        <p class="mt-4 text-lg text-neutral-600 dark:text-neutral-400">
+          Completa tus datos y respuestas. Al enviar, se abrirá tu aplicación de
+          correo con el mensaje preparado para Famdesc.
+        </p>
+      </div>
+
+      <form id="hiring-form" class="grid gap-8">
+        <div
+          class="grid gap-4 rounded-lg border border-neutral-200 p-5 dark:border-neutral-700 sm:grid-cols-2"
+        >
+          {
+            basicFields.map((field) => (
+              <label
+                class="grid gap-2 text-sm font-semibold text-neutral-800 dark:text-neutral-200"
+                for={field.id}
+              >
+                {field.label}
+                <input
+                  class="rounded-lg border-neutral-300 bg-neutral-100 px-4 py-3 text-sm font-normal text-neutral-800 focus:border-salmon-500 focus:ring-salmon-500 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-200"
+                  id={field.id}
+                  name={field.id}
+                  type={field.type}
+                  required={field.id !== "currentOccupation"}
+                />
+              </label>
+            ))
+          }
+        </div>
+
+        <ol id="preguntas" class="grid gap-4">
+          {
+            questions.map((question, index) => (
+              <li class="rounded-lg border border-neutral-200 p-5 dark:border-neutral-700">
+                <label
+                  class="grid gap-3 text-sm font-semibold text-neutral-800 dark:text-neutral-200"
+                  for={`question-${index + 1}`}
+                >
+                  <span class="text-salmon-600 dark:text-salmon-400">
+                    Pregunta {index + 1}
+                  </span>
+                  <span>{question}</span>
+                  <textarea
+                    class="min-h-28 rounded-lg border-neutral-300 bg-neutral-100 px-4 py-3 text-sm font-normal text-neutral-800 focus:border-salmon-500 focus:ring-salmon-500 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-200"
+                    id={`question-${index + 1}`}
+                    name={`question-${index + 1}`}
+                    required
+                  />
+                </label>
+              </li>
+            ))
+          }
+        </ol>
+
+        <div
+          class="grid gap-5 rounded-lg bg-neutral-800 p-6 text-white dark:bg-neutral-950 sm:p-8 lg:grid-cols-[1fr_auto] lg:items-center"
+        >
+          <div>
+            <h2 class="text-2xl font-bold tracking-tight">
+              Enviar candidatura
+            </h2>
+            <p class="mt-3 max-w-2xl text-neutral-300">
+              Revisa tus respuestas antes de enviar. El sitio no guarda estos
+              datos; solo prepara el correo en tu dispositivo.
+            </p>
+          </div>
+
+          <button
+            type="submit"
+            class="hover:bg-salmon-600 focus-visible:ring-salmon-300 inline-flex items-center justify-center rounded-lg bg-salmon-500 px-5 py-3 text-sm font-semibold text-white transition focus:outline-none focus-visible:ring"
+          >
+            Preparar email
+          </button>
+        </div>
+      </form>
+    </div>
+  </section>
+
+  <script>
+    const form = document.querySelector<HTMLFormElement>("#hiring-form");
+
+    form?.addEventListener("submit", (event) => {
+      event.preventDefault();
+
+      const formData = new FormData(form);
+      const questionLabels = Array.from(
+        document.querySelectorAll("#preguntas label"),
+      ).map((label) => label.textContent?.trim().replace(/\s+/g, " ") || "");
+
+      const basicLines = [
+        ["Nombre y apellidos", formData.get("fullName")],
+        ["Edad", formData.get("age")],
+        ["Lugar de residencia", formData.get("location")],
+        ["Teléfono / WhatsApp", formData.get("phone")],
+        ["Ocupación actual", formData.get("currentOccupation")],
+      ];
+
+      const answerLines = questionLabels.map((label, index) => {
+        const answer = formData.get(`question-${index + 1}`) || "";
+        return `${label}\n${answer}`;
+      });
+
+      const body = [
+        "Hola Famdesc,",
+        "",
+        "Me interesa participar en la preselección para Contenido Digital y Marketing.",
+        "",
+        "Datos básicos:",
+        ...basicLines.map(([label, value]) => `${label}: ${value || ""}`),
+        "",
+        "Respuestas:",
+        ...answerLines.map((line, index) => `${index + 1}. ${line}`),
+        "",
+        "Gracias.",
+      ].join("\n");
+
+      const subject = "Preselección - Contenido Digital y Marketing";
+      window.location.href = `mailto:contact@famdesc.com?subject=${encodeURIComponent(
+        subject,
+      )}&body=${encodeURIComponent(body)}`;
+    });
+  </script>
+</MainLayout>

--- a/src/utils/es/navigation.ts
+++ b/src/utils/es/navigation.ts
@@ -1,6 +1,7 @@
 const navBarLinks = [
   { name: "Inicio", url: "/es" },
   { name: "Productos", url: "/products" },
+  { name: "Hiring", url: "/es/hiring" },
   { name: "Nosotros", url: "/about" },
   { name: "Contacto", url: "/es/contact" },
 ];
@@ -17,6 +18,7 @@ const footerLinks = [
     section: "Compañía",
     links: [
       { name: "Sobre nosotros", url: "/about" },
+      { name: "Hiring", url: "/es/hiring" },
       { name: "Contacto", url: "/es/contact" },
       { name: "Lista de espera", url: "/es/waitlist" },
     ],


### PR DESCRIPTION
## General Description

Adds a new Spanish "Hiring" page and navigation link, fixes footer locale detection and link rendering, and hardens the Google Apps Script used by the contact/waitlist endpoint by adding a script version, error codes in JSON responses, and safer email-sending logic.

## Change Details

- **scripts/google-apps-script/contact-waitlist-webapp.gs:**
  - Adds `SCRIPT_VERSION` and includes it in JSON responses.
  - Adds `code` fields to error responses (`validation_failed`, `invalid_form_type`, `internal_error`).
  - Replaces `GmailApp.sendEmail` with `MailApp.sendEmail`.
  - Adds `sendContactEmailSafely_(data)` which wraps email sending in try/catch to avoid crashing the request.
  - Calls `sendContactEmailSafely_` when processing contact form submissions.
  - Removes `contactStatusOptions` and the `applyContactStatusValidation_` function (and its automatic sheet validation).

- **src/components/sections/navbar&footer/FooterSection.astro:**
  - Introduces a `footerLocale` variable to determine locale based on the request path and uses it to select translations.
  - Updates translations/titles to use `footerLocale`.
  - Fixes a callback signature in `.map()` to remove an unused index parameter.
  - Changes the "We're hiring!" badge logic to detect the `/es/hiring` URL and display the badge in Spanish (`Contratando`).

- **src/pages/es/hiring.astro (new file):**
  - Adds a new `/es/hiring` page with Spanish content describing the opportunity, learning outcomes, and a pre-selection form.
  - The form prepares a `mailto:` with the collected answers for submission and includes structured data (JSON-LD).

- **src/utils/es/navigation.ts:**
  - Adds a `Hiring` link to the Spanish navbar and footer sections.

## Motivation and Context

- Provide a Spanish-language "Hiring" landing page to attract and pre-select candidates for content and digital marketing positions.
- Improve i18n correctness for the footer so translations display consistently depending on the page/route.
- Make the contact/waitlist webhook more robust and observable by:
  - exposing a script version in responses for easier debugging,
  - returning machine-friendly error codes the frontend can act on,
  - preventing a failed notification email from breaking the entire request flow.
- Note: removing the automatic "Status" validation in the Google Sheet changes how status values are enforced; reintroduce if you need enforced dropdown validation in the spreadsheet.

## Instructions for Testing

1. Visit the new page at `/es/hiring` in your local or staging environment and verify the page renders with Spanish copy, image, structured data, and the "Llenar formulario" / "Ver preguntas" buttons.
2. Fill out the pre-selection form on `/es/hiring` and submit; confirm the browser opens the default mail client via `mailto:` with the subject and body populated containing the basic fields and question answers.
3. Inspect the footer on Spanish pages (for example `/es` and `/es/hiring`) to confirm footer strings and titles appear in Spanish where appropriate and that the badge `Contratando` is visible next to the `/es/hiring` link.
4. Test the Google Apps Script contact endpoint (POST) with valid and invalid payloads:
   - On success, the JSON response should include `version: SCRIPT_VERSION`.
   - On validation errors, expect `code: "validation_failed"` and `errors` details.
   - On internal failures, expect `code: "internal_error"` (or `invalid_form_type` for unknown form types).
5. Simulate or force an email-sending failure (if feasible in staging) and confirm the endpoint does not return a 500: the save to the sheet should still run and the error should be caught and logged by `sendContactEmailSafely_`.

## Additional Notes

- The change removes `applyContactStatusValidation_` and `contactStatusOptions` from the script; this disables automatic data validation of the "Status" column in the Google Sheet. Reintroduce equivalent validation if required.
- `MailApp` was used instead of `GmailApp` for sending emails; verify required Apps Script permissions and delivery behavior in your environment.
- `SCRIPT_VERSION` was set to `"2026-06-22-contact-email-1"`; increment this value for future releases to aid debugging.
- Ensure `CONFIG.recipientEmail` and other configuration properties are present and correct in the Apps Script project before deploying.
- If you want screenshots of the new page and footer, or a short demo video of the mailto flow, I can generate or capture them on staging.

## Related Issues

- None detected automatically from the comparison.

## Screenshots

No screenshots provided in this PR. 